### PR TITLE
Added support for PTR lookups

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"net"
 
 	//"github.com/miekg/dns"
 	"github.com/miekg/unbound"
@@ -100,7 +101,12 @@ func resolve(line string, attemptNumber int) {
 
 	timeout := make(chan error)
 	go func() {
-		addresses, err = unboundInstance.LookupHost(domain)
+		ip := net.ParseIP(domain)
+		if ip == nil {
+			addresses, err = unboundInstance.LookupHost(domain)
+		} else {
+			addresses, err = unboundInstance.LookupAddr(domain)
+		}
 		timeout <- err
 	}()
 


### PR DESCRIPTION
Simple change to support reverse DNS lookups (PTR records) via LookupAddr()

Uses the net.ParseIP() function to check if the value is a valid IP address. If it is, it uses LookupAddr() to get the PTR record. Otherwise it uses LookupHost() as in the original version to do a regular A record lookup.

I needed something for high speed reverse DNS lookups and this beats nmap -T5 -sL by a mile.
